### PR TITLE
Remove reference to special community

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Firmware - Freifunk Darmstadt</title>
+    <title>Firmware</title>
     <link rel="stylesheet" href="app.css" />
   </head>
   <body>


### PR DESCRIPTION
Keep title clear of any community name so firmware-wizard is reusable in other communities.