### PR TITLE
Use "bullet" image for "nanostations locos"

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -751,11 +751,9 @@ var vendormodels = {
       "nanostation-m5-xw": "M5 XW"
     },
     "NanoStation Loco": {
-      "loco-m-xw": "M2/M5 XW",
-      "loco-m2": "M2 XM",
-      "loco-m2-xw": "M2 XW",
-      "loco-m5": "M5 XM",
-      "loco-m5-xw": "M5 XW"
+      "bullet-m": "M2/M5 XM/XW",
+      "bullet-m2": "M2 XM/XW",
+      "bullet-m5": "M5 XM/XW"
     },
     "PicoStation": "picostation",
     "Rocket": {


### PR DESCRIPTION
According to https://wiki.freifunk.net/Ubiquiti_M-Serie "bullet" ist the right image for both M2/M5 XM/XW variants of the Nanostation loco. These models do only have one ethernet port, and so the switch definition in the bullet image is the right one for "nanostation locos".